### PR TITLE
Fix hardcoded filepath to percy-agent.js

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -31,6 +31,6 @@ function _agentJsFilepath(): string {
   try {
     return require.resolve('@percy/agent/dist/public/percy-agent.js')
   } catch {
-    return 'node_modules/@percy/nightmare/node_modules/@percy/agent/dist/public/percy-agent.js'
+    return 'node_modules/@percy/agent/dist/public/percy-agent.js'
   }
 }


### PR DESCRIPTION
It looks like `@percy/agent`, even though it comes as a dependency of `@percy/nightmare`, is installed at the top level of `node_modules/`, so this is a better fall-back path for accessing `percy-agent.js`.