### PR TITLE
fix: Loosen the `@percy/agent` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^3.1.3"
   },
   "dependencies": {
-    "@percy/agent": "^0.3.0"
+    "@percy/agent": "~0"
   },
   "release": {
     "plugins": [


### PR DESCRIPTION
This will allow us to install all `0.x.x` versions.