### PR TITLE
👷🏼 Prepare project for v2

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -28,4 +28,3 @@ version-resolver:
       - enhancement
   default: patch
 template: '$CHANGES'
-prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,6 @@ jobs:
         with:
           node-version: 14
           registry-url: 'https://registry.npmjs.org'
-      - run: npm publish --tag next
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,16 +7,8 @@
 
 ## Installation
 
-Using yarn:
-
 ```sh-session
-$ yarn add --dev @percy/cli @percy/nightmare@next
-```
-
-Using npm:
-
-```sh-session
-$ npm install --save-dev @percy/cli @percy/nightmare@next
+$ npm install --save-dev @percy/cli @percy/nightmare
 ```
 
 ## Usage
@@ -75,19 +67,52 @@ $ percy exec -- node script.js
 
 ## Upgrading
 
+### Automatically with `@percy/migrate`
+
+We built a tool to help automate migrating to the new CLI toolchain! Migrating
+can be done by running the following commands and following the prompts:
+
+``` shell
+$ npx @percy/migrate
+? Are you currently using @percy/nightmare? Yes
+? Install @percy/cli (required to run percy)? Yes
+? Migrate Percy config file? Yes
+? Upgrade SDK to @percy/nightmare@2.0.0? Yes
+```
+
+This will automatically run the changes described below for you.
+
+### Manually
+
+#### Installing `@percy/cli`
+
 If you're coming from a pre-2.0 version of this package, make sure to install `@percy/cli` after
 upgrading to retain any existing scripts that reference the Percy CLI command.
 
-Using yarn:
-
-```sh-session
-$ yarn add --dev @percy/cli
-```
-
-Using npm:
-
 ```sh-session
 $ npm install --save-dev @percy/cli
+```
+
+#### Import change
+
+If you're coming from a pre-2.0 version of this package, the `percySnapshot` function is now the default
+export.
+
+```javascript
+// before
+const { percySnapshot } = require('@percy/nightmare);
+
+// after
+const percySnapshot = require('@percy/nightmare);
+```
+
+#### Migrating Config
+
+If you have a previous Percy configuration file, migrate it to the newest version with the
+[`config:migrate`](https://github.com/percy/cli/tree/master/packages/cli-config#percy-configmigrate-filepath-output) command:
+
+```sh-session
+$ percy config:migrate
 ```
 
 ### Migrating Config

--- a/README.md
+++ b/README.md
@@ -100,22 +100,13 @@ export.
 
 ```javascript
 // before
-const { percySnapshot } = require('@percy/nightmare);
+const { percySnapshot } = require('@percy/nightmare');
 
 // after
-const percySnapshot = require('@percy/nightmare);
+const percySnapshot = require('@percy/nightmare');
 ```
 
 #### Migrating Config
-
-If you have a previous Percy configuration file, migrate it to the newest version with the
-[`config:migrate`](https://github.com/percy/cli/tree/master/packages/cli-config#percy-configmigrate-filepath-output) command:
-
-```sh-session
-$ percy config:migrate
-```
-
-### Migrating Config
 
 If you have a previous Percy configuration file, migrate it to the newest version with the
 [`config:migrate`](https://github.com/percy/cli/tree/master/packages/cli-config#percy-configmigrate-filepath-output) command:


### PR DESCRIPTION
## What is this?

This prepares the project for a v2 release by:

- Updating the README to remove `@next` from install commands
- Adding upgrading/migrating information to the README
- Updating release config to release on the stable channel